### PR TITLE
Markdown Lint, Update Mapping Instructions and Server Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # [MinecraftServerControl.github.io](https://MinecraftServerControl.github.io)
+
 Repo for the MinecraftServerControl documentation hosted on Github Pages.

--- a/docs/mscs/adjusting-world-server-properties/adjusting-world-server-properties.md
+++ b/docs/mscs/adjusting-world-server-properties/adjusting-world-server-properties.md
@@ -1,15 +1,15 @@
 ---
 layout: default
-title: Adjusting world & server properties
+title: Adjusting World & Server Properties
 nav_order: 4
 has_children: true
 permalink: /docs/mscs/adjusting-world-server-properties
 ---
 
-# Adjusting world & server properties
+# Adjusting World & Server Properties
 {: .no_toc }
 
-## Table of contents
+## Table of Contents
 {: .no_toc .text-delta }
 
 1. TOC
@@ -18,251 +18,305 @@ permalink: /docs/mscs/adjusting-world-server-properties
 ---
 
 ## Introduction
-By default, every world in MSCS inherits from a global server properties file called `mscs.defaults`. 
-These defaults can be overidden on a per-world basis by creating an `mscs.properties` file in the directories of the
-world(s) you wish to overwrite. Only properties that will be changed need to be copied into the `mscs.properties` file--the MSCS script will use the global `mscs.defaults` for any properties that are left out.
 
-What follows are the global server properties
-and individual world properties MSCS currently has available.
-Additionally, we list examples of [common configuration settings](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties#common-configuration-settings) at the end of this page.
+By default, every world in MSCS inherits from a global server properties file called `mscs.defaults`. These defaults can
+be overidden on a per-world basis by creating an `mscs.properties` file in the directories of the world(s) you wish to
+overwrite. Only properties that will be changed need to be copied into the `mscs.properties` file--the MSCS script will
+use the global `mscs.defaults` for any properties that are left out.
 
-Examples of how to configure the properties for major server mods can be found on the sidebar--specifically for [PaperMC](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties/papermc),
-[SpigotMC](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties/spigotmc), [Forge](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties/forge), [BungeeCord](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties/bungeecord), and [Technic/Tekkit Pack](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties/technic-tekkit-pack). 
+What follows are the global server properties and individual world properties MSCS currently has available.
+Additionally, we list examples of [common configuration settings](adjusting-world-server-properties#common-configuration-settings)
+at the end of this page.
 
+Examples of how to configure the properties for major server mods can be found on the sidebar--specifically for
+[PaperMC][papermc], [SpigotMC][spigotmc], [Forge][forge], [BungeeCord][bungeecord], and [Technic/Tekkit Pack][technic].
 
 ---
 
-## Global server properties
-The global server properties file is called `mscs.defaults`. As mentioned
-above, all MSCS worlds inherit properties from this file unless the properties
-are overridden in the world's `mscs.properties` file. 
+## Global Server Properties
 
-This `mscs.defaults` file can be found at
-`/opt/mscs/mscs.defaults`. 
+The global server properties file is called `mscs.defaults`. As mentioned above, all MSCS worlds inherit properties from
+this file unless the properties are overridden in the world's `mscs.properties` file.
 
-When using the `msctl` script in multi-user mode,
-the `mscs.defaults` file can be found at either `$HOME/mscs.defaults` or
-`$HOME/.config/mscs/mscs.defaults` (both are valid locations).
-Please note that `$HOME` represents the 
-home directory of the user that is running the script.
+This `mscs.defaults` file can be found at `/opt/mscs/mscs.defaults`.
 
-Listed below are the global server properties currently available. The properties that are set
-already are the defaults that come with the script (properties that are empty
-have no defaults). You can change any of the properties to your liking (including defaults) by adding them
-to the `mscs.defaults` file or editing them if they are already in the file. 
+When using the `msctl` script in multi-user mode, the `mscs.defaults` file can be found at either `$HOME/mscs.defaults`
+or `$HOME/.config/mscs/mscs.defaults` (both are valid locations). Please note that `$HOME` represents the home directory
+of the user that is running the script.
 
-    # Location of the mscs files.
-    mscs-location=/opt/mscs
+Listed below are the global server properties currently available. The properties that are set already are the defaults
+that come with the script (properties that are empty have no defaults). You can change any of the properties to your
+liking (including defaults) by adding them to the `mscs.defaults` file or editing them if they are already in the file.
 
-    # Location of world files.
-    mscs-worlds-location=/opt/mscs/worlds
+```ini
+; Location of the mscs files.
+mscs-location=/opt/mscs
 
-    # URL to download the version_manifest.json file.
-    mscs-versions-url=https://launchermeta.mojang.com/mc/game/version_manifest.json
+; Location of world files.
+mscs-worlds-location=/opt/mscs/worlds
 
-    # Location of the version_manifest.json file.
-    mscs-versions-json=/opt/mscs/version_manifest.json
+; URL to download the version_manifest.json file.
+mscs-versions-url=https://launchermeta.mojang.com/mc/game/version_manifest.json
 
-    # Length in minutes to keep the version_manifest.json file before updating.
-    mscs-versions-duration=30
+; Location of the version_manifest.json file.
+mscs-versions-json=/opt/mscs/version_manifest.json
 
-    # Length in minutes to keep lock files before removing.
-    mscs-lockfile-duration=1440
+; Length in minutes to keep the version_manifest.json file before updating.
+mscs-versions-duration=30
 
-    # Default world name.
-    mscs-default-world=world
+; Length in minutes to keep lock files before removing.
+mscs-lockfile-duration=1440
 
-    # Default Port.
-    mscs-default-port=25565
+; Properties to return for detailed listings.
+mscs-detailed-listing=motd server-ip server-port max-players level-type online-mode
 
-    # Default IP address.
-    mscs-default-ip=
+; Default world name.
+mscs-default-world=world
 
-    # Default version type (release or snapshot).
-    mscs-default-version-type=release
+; Default Port.
+mscs-default-port=25565
 
-    # Default version of the client software.
-    mscs-default-client-version=$CURRENT_VERSION
+; Default IP address. Leave this blank unless you want to bind all world
+; servers to a single network interface by default.
+mscs-default-ip=
 
-    # Default .jar file for the client software.
-    mscs-default-client-jar=$CLIENT_VERSION.jar
+; Default version type (release or snapshot).
+mscs-default-version-type=release
 
-    # Default download URL for the client software.
-    mscs-default-client-url=
+; Default version of the client software. This sets the $CLIENT_VERSION
+; variable. You can use the $CURRENT_VERSION variable to access the latest
+; version based on the version type selected.
+mscs-default-client-version=$CURRENT_VERSION
 
-    # Default download URL for the client software.
-    mscs-default-client-location=/opt/mscs/.minecraft/versions/$CLIENT_VERSION
+; Default .jar file for the client software. The $CLIENT_VERSION variable
+; allows access to the client version selected.
+mscs-default-client-jar=$CLIENT_VERSION.jar
 
-    # Default version of the server software.
-    mscs-default-server-version=$CURRENT_VERSION
+; Default download URL for the client software. The $CLIENT_VERSION variable
+; allows access to the client version selected.
+mscs-default-client-url=
 
-    # Default arguments for the JVM.
-    mscs-default-jvm-args=
+; Default location of the client .jar file. The $CLIENT_VERSION variable
+; allows access to the client version selected.
+mscs-default-client-location=/opt/mscs/.minecraft/versions/$CLIENT_VERSION
 
-    # Default .jar file for the server software.
-    mscs-default-server-jar=minecraft_server.$SERVER_VERSION.jar
+; Default version of the server software. This sets the $SERVER_VERSION
+; variable. You can use the $CURRENT_VERSION variable to access the latest
+; version based on the version type selected.
+mscs-default-server-version=$CURRENT_VERSION
 
-    # Default download URL for the server software.
-    mscs-default-server-url=
+; Default arguments for the JVM. This sets the $JVM_ARGS variable.
+mscs-default-jvm-args=
 
-    # Default arguments for a world server.
-    mscs-default-server-args=nogui
+; Default .jar file for the server software. This sets the $SERVER_JAR
+; variable. The $SERVER_VERSION variable allows access to the server version
+; selected.
+mscs-default-server-jar=minecraft_server.$SERVER_VERSION.jar
 
-    # Default initial amount of memory for a world server.
-    mscs-default-initial-memory=128M
+; Default download URL for the server software. The $SERVER_VERSION variable
+; allows access to the server version selected.
+mscs-default-server-url=
 
-    # Default maximum amount of memory for a world server.
-    mscs-default-maximum-memory=2048M
+; Default arguments for a world server. This sets the $SERVER_ARGS variable.
+mscs-default-server-args=nogui
 
-    # Default location of the server .jar file.
-    mscs-default-server-location=/opt/mscs/server
+; Default initial amount of memory for a world server. This sets the
+; $INITIAL_MEMORY variable.
+mscs-default-initial-memory=128M
 
-    # Default command to run for a world server.
-    mscs-default-server-command=$JAVA -Xms$INITIAL_MEMORY -Xmx$MAXIMUM_MEMORY -jar $SERVER_LOCATION/$SERVER_JAR $SERVER_ARGS
+; Default maximum amount of memory for a world server. This sets the
+; $MAXIMUM_MEMORY variable.
+mscs-default-maximum-memory=2048M
 
-    # Location to store backup files.
-    mscs-backup-location=/opt/mscs/backups
+; Default location of the server .jar file. This sets the $SERVER_LOCATION
+; variable.
+mscs-default-server-location=/opt/mscs/server
 
-    # Location of the backup log file.
-    mscs-backup-log=/opt/mscs/backups/backup.log
+; Default command to run for a world server. You can use the $JAVA variable to
+; access the results of $(which java). The $INITIAL_MEMORY and $MAXIMUM_MEMORY
+; variables provide access to the amounts of memory selected. The
+; $SERVER_LOCATION and $SERVER_JAR variables provide access to the location
+; and file name of the server software selected. The $JVM_ARGS variable
+; provides access to the Java virtual machine arguments for the world server
+; selected. The $SERVER_ARGS variable provides access to the server arguments
+; for the world server selected.
+mscs-default-server-command=$JAVA -Xms$INITIAL_MEMORY -Xmx$MAXIMUM_MEMORY $JVM_ARGS -jar $SERVER_LOCATION/$SERVER_JAR $SERVER_ARGS
 
-    # Length in days that backups survive. A value less than 1 disables backup deletion.
-    mscs-backup-duration=15
+; Location to store backup files.
+mscs-backup-location=/opt/mscs/backups
 
-    # Length in days that logs survive. A value less than 1 disables log deletion.
-    mscs-log-duration=15
+; Location of the backup log file.
+mscs-backup-log=/opt/mscs/backups/backup.log
 
-    # Properties to return for detailed listings.
-    mscs-detailed-listing=motd server-ip server-port max-players level-type online-mode
+; Files and directories excluded from backups. Each path is relative to the
+; world/<world> directory. Separate each entry with commas.
+mscs-backup-excluded-files=
 
-    # Enable the mirror option by default for worlds.
-    # 0 = disabled (default), 1 = enabled.
-    mscs-enable-mirror=0
+; Length in days that backups survive. A value less than 1 disables backup deletion.
+mscs-backup-duration=15
 
-    # Default path for the mirror files.
-    mscs-mirror-path=/dev/shm/mscs
+; Length in days that logs survive. A value less than 1 disables log deletion.
+mscs-log-duration=15
 
-    # Location of Overviewer.
-    mscs-overviewer-bin=/usr/bin/overviewer.py
+; Enable the mirror option by default for worlds (default disabled). Change
+; to a 1 to enable.
+mscs-enable-mirror=0
 
-    # URL for Overviewer.
-    mscs-overviewer-url=http://overviewer.org
+; Default path for the mirror files.
+mscs-mirror-path=/dev/shm/mscs
 
-    # Location of Overviewer generated map files.
-    mscs-maps-location=/opt/mscs/maps
+; Location of Overviewer.
+mscs-overviewer-bin=/usr/bin/overviewer.py
 
-    # URL for accessing Overviewer generated maps.
-    mscs-maps-url=http://minecraft.server.com/maps
-    
+; URL for Overviewer.
+mscs-overviewer-url=http://overviewer.org
+
+; Location of Overviewer generated map files.
+mscs-maps-location=/opt/mscs/maps
+
+; URL for accessing Overviewer generated maps.
+mscs-maps-url=http://minecraft.server.com/maps
+```
+
 The following variables may be used in some of the above properties:
-* $JAVA                - The Java virtual machine.
-* $CURRENT_VERSION     - The current Mojang Minecraft release version.
-* $CLIENT_VERSION      - The version of the client software.
-* $SERVER_VERSION      - The version of the server software.
-* $JVM_ARGS            - The arguments to the JVM.
-* $SERVER_JAR          - The .jar file to run for the server.
-* $SERVER_ARGS         - The arguments to the server.
-* $INITIAL_MEMORY      - The initial amount of memory for the server.
-* $MAXIMUM_MEMORY      - The maximum amount of memory for the server.
-* $SERVER_LOCATION     - The location of the server .jar file.
+
+- `$JAVA` - The Java virtual machine (`which java`).
+- `$CURRENT_VERSION` - The current Mojang Minecraft release version.
+- `$CLIENT_VERSION` - The version of the client software.
+- `$SERVER_VERSION` - The version of the server software.
+- `$JVM_ARGS` - The arguments to the JVM.
+- `$SERVER_JAR` - The .jar file to run for the server.
+- `$SERVER_ARGS` - The arguments to the server.
+- `$INITIAL_MEMORY` - The initial amount of memory for the server.
+- `$MAXIMUM_MEMORY` - The maximum amount of memory for the server.
+- `$SERVER_LOCATION` - The location of the server .jar file.
+- `$WORLD_NAME` - The name of the world.
 
 ---
 
-## Individual world properties
-As mentioned earlier, each world server can override the default, global server values by
-adding properties to the world's `mscs.properties` file. The
-`mscs.properties` file can be found in every world folder (for instance, if
-you had a world called `myWorld`, the path would be
-`/opt/mscs/worlds/myWorld/mscs.properties`). 
+## Individual World Properties
 
-Listed below are the individual world properties currently available. The properties that are set
-already are the defaults that come with the script (properties that are empty
-have no defaults). You can change any of the properties to your liking (including defaults) by adding them
-to the `mscs.properties` file or editing them if they are already in the file. 
+As mentioned earlier, each world server can override the default, global server values by adding properties to the
+world's `mscs.properties` file. The `mscs.properties` file can be found in every world folder (for instance, if you had
+a world called `myWorld`, the path would be `/opt/mscs/worlds/myWorld/mscs.properties`).
 
-    # Enable or disable the world server.
-    mscs-enabled=true
+Listed below are the individual world properties currently available. The properties that are set already are the
+defaults that come with the script (properties that are empty have no defaults). You can change any of the properties to
+your liking (including defaults) by adding them to the `mscs.properties` file or editing them if they are already in
+the file.
 
-    # Assign the version type (release or snapshot).
-    mscs-version-type=release
+```ini
+; Enable or disable the world server.
+mscs-enabled=true
 
-    # Assign the version of the client software.
-    mscs-client-version=$CURRENT_VERSION
+; Assign the version type (release or snapshot).
+mscs-version-type=release
 
-    # Assign the .jar file for the client software.
-    mscs-client-jar=$CLIENT_VERSION.jar
+; Assign the version of the client software. This sets the $CLIENT_VERSION
+; variable. You can use the $CURRENT_VERSION variable to access the latest
+; version based on the version type selected.
+mscs-client-version=$CURRENT_VERSION
 
-    # Assign the download URL for the client software.
-    mscs-client-url=https://s3.amazonaws.com/Minecraft.Download/versions/$CLIENT_VERSION/$CLIENT_VERSION.jar
+; Assign the .jar file for the client software. The $CLIENT_VERSION variable
+; allows access to the client version selected.
+mscs-client-jar=$CLIENT_VERSION.jar
 
-    # Assign the location of the client .jar file.
-    mscs-client-location=/opt/mscs/.minecraft/versions/$CLIENT_VERSION
+; Assign the download URL for the client software. The $CLIENT_VERSION variable
+; allows access to the client version selected.
+mscs-client-url=https://s3.amazonaws.com/Minecraft.Download/versions/$CLIENT_VERSION/$CLIENT_VERSION.jar
 
-    # Assign the version of the server software.
-    mscs-server-version=$CURRENT_VERSION
+; Assign the location of the client .jar file. The $CLIENT_VERSION variable
+; allows access to the client version selected.
+mscs-client-location=/opt/mscs/.minecraft/versions/$CLIENT_VERSION
 
-    # Assign the arguments to the JVM.
-    mscs-jvm-args=
+; Assign the version of the server software. This sets the $SERVER_VERSION
+; variable. You can use the $CURRENT_VERSION variable to access the latest
+; version based on the version type selected.
+mscs-server-version=$CURRENT_VERSION
 
-    # Assign the .jar file for the server software.
-    mscs-server-jar=minecraft_server.$SERVER_VERSION.jar
+; Assign the arguments to the JVM. This sets the $JVM_ARGS variable.
+mscs-jvm-args=
 
-    # Assign the download URL for the server software.
-    mscs-server-url=https://s3.amazonaws.com/Minecraft.Download/versions/$SERVER_VERSION/minecraft_server.$SERVER_VERSION.jar
+; Assign the .jar file for the server software. This sets the $SERVER_JAR
+; variable. The $SERVER_VERSION variable allows access to the server version
+; selected.
+mscs-server-jar=minecraft_server.$SERVER_VERSION.jar
 
-    # Assign the arguments to the server.
-    mscs-server-args=nogui
+; Assign the download URL for the server software. The $SERVER_VERSION variable
+; allows access to the server version selected.
+mscs-server-url=https://s3.amazonaws.com/Minecraft.Download/versions/$SERVER_VERSION/minecraft_server.$SERVER_VERSION.jar
 
-    # Assign the initial amount of memory for the server.
-    mscs-initial-memory=128M
+; Assign the arguments to the server. This sets the $SERVER_ARGS variable.
+mscs-server-args=nogui
 
-    # Assign the maximum amount of memory for the server.
-    mscs-maximum-memory=2048M
+; Assign the initial amount of memory for the server. This sets the
+; $INITIAL_MEMORY variable.
+mscs-initial-memory=128M
 
-    # Assign the location of the server .jar file.
-    mscs-server-location=/opt/mscs/server
+; Assign the maximum amount of memory for the server. This sets the
+; $MAXIMUM_MEMORY variable.
+mscs-maximum-memory=2048M
 
-    # Assign the command to run for the server.
-    mscs-server-command=$JAVA -Xms$INITIAL_MEMORY -Xmx$MAXIMUM_MEMORY -jar $SERVER_LOCATION/$SERVER_JAR $SERVER_ARGS
-    
+; Assign the location of the server .jar file. This sets the $SERVER_LOCATION
+; variable.
+mscs-server-location=/opt/mscs/server
+
+; Assign the command to run for the server. You can use the $JAVA variable to
+; access the results of $(which java). The $INITIAL_MEMORY and $MAXIMUM_MEMORY
+; variables provide access to the amounts of memory selected. The
+; $SERVER_LOCATION and $SERVER_JAR variables provide access to the location
+; and file name of the server software selected. The $JVM_ARGS variable
+; provides access to the Java virtual machine arguments for the world server
+; selected. The $SERVER_ARGS variable provides access to the server arguments
+; for the world server selected.
+mscs-server-command=$JAVA -Xms$INITIAL_MEMORY -Xmx$MAXIMUM_MEMORY $JVM_ARGS -jar $SERVER_LOCATION/$SERVER_JAR $SERVER_ARGS
+```
+
 The following variables may be used in some of the values of the above keys:
-* $JAVA - The Java virtual machine.
-* $CURRENT_VERSION - The current Mojang Minecraft release version.
-* $CLIENT_VERSION - The version of the client software.
-* $SERVER_VERSION - The version of the server software.
-* $SERVER_JAR - The .jar file to run for the server.
-* $SERVER_ARGS - The arguments to the server.
-* $INITIAL_MEMORY - The initial amount of memory for the server.
-* $MAXIMUM_MEMORY - The maximum amount of memory for the server.
-* $SERVER_LOCATION - The location of the server .jar file.
+
+- `$JAVA` - The Java virtual machine.
+- `$CURRENT_VERSION` - The current Mojang Minecraft release version.
+- `$CLIENT_VERSION` - The version of the client software.
+- `$SERVER_VERSION` - The version of the server software.
+- `$JVM_ARGS` - The arguments to the JVM.
+- `$SERVER_JAR` - The .jar file to run for the server.
+- `$SERVER_ARGS` - The arguments to the server.
+- `$INITIAL_MEMORY` - The initial amount of memory for the server.
+- `$MAXIMUM_MEMORY` - The maximum amount of memory for the server.
+- `$SERVER_LOCATION` - The location of the server .jar file.
 
 ---
 
-## Common configuration settings
+## Common Configuration Settings
+
 The examples below assumes you are editing the world's `mscs.properties`.
 
-### Set world's server version
+### Set World's Server Version
+
 Use a specific release:
-```
+
+```ini
 mscs-server-version=1.14
 mscs-client-version=1.14
 ```
 
 Use the latest snapshot:
-```
+
+```ini
 mscs-version-type=snapshot
 ```
 
 Use a specific snapshot:
-```
+
+```ini
 mscs-version-type=snapshot
 mscs-client-version=14w11b
 mscs-server-version=14w11b
 ```
 
+### Set World's Memory
 
-### Set world's memory
-```
+```ini
 # Assign the initial amount of memory for the server.
 mscs-initial-memory=128M
 
@@ -270,18 +324,30 @@ mscs-initial-memory=128M
 mscs-maximum-memory=2048M
 ```
 
-### Set world's logging setting
-Want to customize the server logs? You can configure log4j by setting `mscs-jvm-args`.
+### Set World's Logging Setting
+
+Want to customize the server logs? You can configure log4j by setting
+`mscs-jvm-args`.
+
 Example setting:
 
-```
+```ini
 mscs-jvm-args=-Dlog4j.configurationFile=/opt/mscs/log4j2.xml
 ```
 
-### Set world's custom java command
+### Set World's Custom Java Command
+
 Do you want a crazy Java command? You can do it with `mscs-server-command`:
-```
+
+```ini
 mscs-server-command=$JAVA -Xms$INITIAL_MEMORY -Xmx$MAXIMUM_MEMORY -Xincgc -XX:NewRatio=3 -XX:+UseThreadPriorities -XX:CMSFullGCsBeforeCompaction=1 -XX:SoftRefLRUPolicyMSPerMB=2048 -XX:+CMSParallelRemarkEnabled -XX:+UseParNewGC -XX:+UseAdaptiveSizePolicy -XX:+DisableExplicitGC -Xnoclassgc -oss4M -ss4M -XX:+UseFastAccessorMethods -XX:CMSInitiatingOccupancyFraction=90 -XX:+UseConcMarkSweepGC -XX:UseSSE=4 -XX:+UseCMSCompactAtFullCollection -XX:ParallelGCThreads=8 -XX:+AggressiveOpts -Djava.awt.headless=true -jar $SERVER_LOCATION/$SERVER_JAR $SERVER_ARGS
 ```
-Yes, this command could be used... but we do not guarantee that it will work or that it will make a server any faster/better/harder/stronger.
 
+Yes, this command could be used... but we do not guarantee that it will work or that it will make a server any
+faster/better/harder/stronger.
+
+[papermc]: papermc
+[spigotmc]: spigotmc
+[forge]: forge
+[bungeecord]: bungeecord
+[technic]: technic-tekkit-pack

--- a/docs/mscs/adjusting-world-server-properties/bungeecord.md
+++ b/docs/mscs/adjusting-world-server-properties/bungeecord.md
@@ -2,40 +2,56 @@
 layout: default
 title: BungeeCord
 nav_order: 5
-parent: Adjusting world & server properties
+parent: Adjusting World & Server Properties
 permalink: /docs/mscs/adjusting-world-server-properties/bungeecord
 ---
 
 # BungeeCord
-[BungeeCord](https://www.spigotmc.org/wiki/bungeecord/) is a proxy server that sits between the Minecraft client and server that allows players on a server to easily transfer between worlds (regardless of whether the world is running on vanilla, Forge, SpigotMC, etc). The setup for BungeeCord can be rather complex. To fully understand the configuration options available, visit the [BungeeCord Configuration Guide](https://www.spigotmc.org/wiki/bungeecord-configuration-guide/).
 
-Although BungeeCord is not a normal Minecraft server, MSCS is able to control the server as if it were with a little work. Lets start by creating a fake world named `lobby` on the default port of `25565`.
+[BungeeCord][bungeecord] is a proxy server that sits between the Minecraft client and server that allows players on a
+server to easily transfer between worlds (regardless of whether the world is running on vanilla, Forge, SpigotMC, etc).
+The setup for BungeeCord can be rather complex. To fully understand the configuration options available, visit the
+[BungeeCord Configuration Guide][bungeecord_config_guide].
 
-    mscs create lobby 25565
+Although BungeeCord is not a normal Minecraft server, MSCS is able to control the server as if it were with a little
+work. Lets start by creating a fake world named `lobby` on the default port of `25565`.
+
+```bash
+mscs create lobby 25565
+```
 
 `lobby` can be replaced with any name. Ensure that port `25565` is an unused port, or change it if nessessary.
 
 Change the directory to the world that was created:
 
-    cd /opt/mscs/worlds/lobby
+```bash
+cd /opt/mscs/worlds/lobby
+```
 
-This will create the directory `lobby` in `/opt/mscs/worlds` as well as the `server.properties` and `mscs.properties` files:
+This will create the directory `lobby` in `/opt/mscs/worlds` as well as the `server.properties` and `mscs.properties`
+files:
 
 `server.properties` is not needed for this server. Delete this file.
 
-    rm server.properties
+```bash
+rm server.properties
+```
 
 Modify the `mscs.properties` file and add/alter these lines:
 
-    mscs-enabled=true
-    mscs-server-jar=BungeeCord.jar
-    mscs-server-url=
-    mscs-initial-memory=512M
-    mscs-maximum-memory=512M
-
-Create a `config.yml` file that will apply for the worlds on this server. For example: `alpha` and `beta` on ports `25566` and `25567` respectively. Note, change the name of the admin from `username` to the Minecraft player name that will be administering BungeeCord.
-
+```ini
+mscs-enabled=true
+mscs-server-jar=BungeeCord.jar
+mscs-server-url=
+mscs-initial-memory=512M
+mscs-maximum-memory=512M
 ```
+
+Create a `config.yml` file that will apply for the worlds on this server. For example: `alpha` and `beta` on ports
+`25566` and `25567` respectively. Note, change the name of the admin from `username` to the Minecraft player name that
+will be administering BungeeCord.
+
+```yaml
 groups:
   username:
   - admin
@@ -79,33 +95,53 @@ ip_forward: false
 online_mode: true
 ```
 
-Change to the `/opt/mscs/server/` directory, [download](http://ci.md-5.net/job/BungeeCord/) the BungeeCord server jar `BungeeCord.jar`, and run the following as the `minecraft` user (`sudo su minecraft`):
+Change to the `/opt/mscs/server/` directory, [download][download] the BungeeCord server jar `BungeeCord.jar`, and run
+the following as the `minecraft` user (`sudo su minecraft`):
 
-    cd /opt/mscs/server
-    wget http://ci.md-5.net/job/BungeeCord/lastSuccessfulBuild/artifact/bootstrap/target/BungeeCord.jar
+```bash
+cd /opt/mscs/server
+wget http://ci.md-5.net/job/BungeeCord/lastSuccessfulBuild/artifact/bootstrap/target/BungeeCord.jar
+```
 
-Create the two worlds `alpha` and `beta`. Since both worlds will only be accessed locally by the BungeeCord proxy server, use the optional `ip` argument for the `create` function to limit access to localhost:
+Create the two worlds `alpha` and `beta`. Since both worlds will only be accessed locally by the BungeeCord proxy
+server, use the optional `ip` argument for the `create` function to limit access to localhost:
 
-    mscs create alpha 25566 127.0.0.1
-    mscs create beta 25567 127.0.0.1
+```bash
+mscs create alpha 25566 127.0.0.1
+mscs create beta 25567 127.0.0.1
+```
 
 Start the worlds to set themselves up:
 
-    mscs start alpha
-    mscs start beta
+```bash
+mscs start alpha
+mscs start beta
+```
 
 If the servers fail to start, the `eula.txt` file may need to be edited and accepted:
 
-    editor /opt/mscs/worlds/alpha/eula.txt
-    editor /opt/mscs/worlds/beta/eula.txt
+```bash
+editor /opt/mscs/worlds/alpha/eula.txt
+editor /opt/mscs/worlds/beta/eula.txt
+```
 
-BungeeCord requires that the world servers be in offline mode. BungeeCord handles authentication as long as `online_mode` is set to `true` in `config.yml` like the example above. To do this, edit the `server.properties` file for the `alpha` and `beta` worlds and change the values of `online-mode` in both files to `false`.
+BungeeCord requires that the world servers be in offline mode. BungeeCord handles authentication as long as
+`online_mode` is set to `true` in `config.yml` like the example above. To do this, edit the `server.properties` file for
+the `alpha` and `beta` worlds and change the values of `online-mode` in both files to `false`.
 
-    editor /opt/mscs/worlds/alpha/server.properties
-    editor /opt/mscs/worlds/beta/server.properties
+```bash
+editor /opt/mscs/worlds/alpha/server.properties
+editor /opt/mscs/worlds/beta/server.properties
+```
 
 Finally, if everything is correctly setup, we can start the worlds:
 
-    mscs start lobby
-    mscs start alpha
-    mscs start beta
+```bash
+mscs start lobby
+mscs start alpha
+mscs start beta
+```
+
+[bungeecord]: https://www.spigotmc.org/wiki/bungeecord/
+[bungeecord_config_guide]: https://www.spigotmc.org/wiki/bungeecord-configuration-guide/
+[download]: http://ci.md-5.net/job/BungeeCord/

--- a/docs/mscs/adjusting-world-server-properties/forge.md
+++ b/docs/mscs/adjusting-world-server-properties/forge.md
@@ -2,52 +2,75 @@
 layout: default
 title: Forge
 nav_order: 3
-parent: Adjusting world & server properties
+parent: Adjusting World & Server Properties
 permalink: /docs/mscs/adjusting-world-server-properties/forge
 ---
 
 # Forge
-[Forge](http://www.minecraftforge.net/) has an easy to use installer that can be used to install all of the needed files to run a Forge server, starting with version `1.6.2-9.10.0.818`. To install a version compatible with Minecraft 1.8.9, [download](http://files.minecraftforge.net/) the Forge installer `forge-x.x-xx.xx.x.xxxx-installer` and run the following as the `minecraft` user (`sudo su minecraft`):
 
-    cd /opt/mscs/server
-    wget http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.8.9-11.15.1.1722/forge-1.8.9-11.15.1.1722-installer.jar
-    java -jar forge-1.8.9-11.15.1.1722-installer.jar --installServer
+[Forge][forge] has an easy to use installer that can be used to install all of the needed files to run a Forge server,
+starting with version `1.6.2-9.10.0.818`. To install a version compatible with Minecraft 1.8.9, [download][download] the
+Forge installer `forge-x.x-xx.xx.x.xxxx-installer` and run the following as the `minecraft` user (`sudo su minecraft`):
 
-The installer should install the forge server jar to `/opt/mscs/server/forge-1.8-11.14.2.1434-universal.jar` and a bunch of library files in `/opt/mscs/server/libraries/`.
+```bash
+cd /opt/mscs/server
+wget http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.8.9-11.15.1.1722/forge-1.8.9-11.15.1.1722-installer.jar
+java -jar forge-1.8.9-11.15.1.1722-installer.jar --installServer
+```
+
+The installer should install the forge server jar to `/opt/mscs/server/forge-1.8-11.14.2.1434-universal.jar` and a bunch
+of library files in `/opt/mscs/server/libraries/`.
 
 Create a new server (if necessary):
 
-    mscs create forge 25565
+```bash
+mscs create forge 25565
+```
 
 `forge` can be replaced with any name. Ensure that port `25565` is an unused port, or change it if nessessary.
 
-This will create the directory `forge` in `/opt/mscs/worlds` as well as the `server.properties` and `mscs.properties` files:
+This will create the directory `forge` in `/opt/mscs/worlds` as well as the `server.properties` and `mscs.properties`
+files:
 
 Change the directory to the world that was created:
 
-    cd /opt/mscs/worlds/forge
+```bash
+cd /opt/mscs/worlds/forge
+```
 
 Modify the `mscs.properties` file and add/alter these lines, replacing versions and file paths as needed:
 
-    mscs-client-version=1.8.4
-    mscs-server-version=1.8.4
-    mscs-server-jar=forge-1.8.9-11.15.1.1722-universal.jar
-    mscs-server-url=
+```ini
+mscs-client-version=1.8.4
+mscs-server-version=1.8.4
+mscs-server-jar=forge-1.8.9-11.15.1.1722-universal.jar
+mscs-server-url=
+```
 
 Start the server:
 
-    mscs start forge
+```bash
+mscs start forge
+```
 
 If the server fails to start, the `eula.txt` file may need to be edited and accepted:
 
-    editor /opt/mscs/worlds/forge/eula.txt
+```bash
+editor /opt/mscs/worlds/forge/eula.txt
+```
 
-The server should start up and run  
+The server should start up and run
+
 The server startup can be monitored by running:
 
-    mscs console forge
+```bash
+mscs console forge
+```
 
 Once you are done watching the server boot up, you can press `<Ctrl-D>` to detach.
 
-Simply add mods as you would normally by dragging them into the `/opt/mscs/worlds/forge/mods` folder,
-assuming `forge` is the name of your world.
+Simply add mods as you would normally by dragging them into the `/opt/mscs/worlds/forge/mods` folder, assuming `forge`
+is the name of your world.
+
+[forge]: http://www.minecraftforge.net/
+[download]: http://files.minecraftforge.net/

--- a/docs/mscs/adjusting-world-server-properties/forge.md
+++ b/docs/mscs/adjusting-world-server-properties/forge.md
@@ -8,18 +8,19 @@ permalink: /docs/mscs/adjusting-world-server-properties/forge
 
 # Forge
 
-[Forge][forge] has an easy to use installer that can be used to install all of the needed files to run a Forge server,
-starting with version `1.6.2-9.10.0.818`. To install a version compatible with Minecraft 1.8.9, [download][download] the
-Forge installer `forge-x.x-xx.xx.x.xxxx-installer` and run the following as the `minecraft` user (`sudo su minecraft`):
+[Forge][forge] has an easy to use installer that can be used to install all of the needed files to run a Forge server.
+To install a version compatible with Minecraft 1.16.4, [download][download] the Forge installer `forge-forge-x.x.x-x.x.x-installer`
+and run the following as the `minecraft` user (`sudo su minecraft`):
 
 ```bash
-cd /opt/mscs/server
-wget http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.8.9-11.15.1.1722/forge-1.8.9-11.15.1.1722-installer.jar
-java -jar forge-1.8.9-11.15.1.1722-installer.jar --installServer
+mkdir -p /opt/mscs/server/forge-1.16.4-35.1.7
+cd /opt/mscs/server/forge-1.16.4-35.1.7
+wget https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.16.4-35.1.7/forge-1.16.4-35.1.7-installer.jar
+java -jar forge-1.16.4-35.1.7-installer.jar --installServer
 ```
 
-The installer should install the forge server jar to `/opt/mscs/server/forge-1.8-11.14.2.1434-universal.jar` and a bunch
-of library files in `/opt/mscs/server/libraries/`.
+The installer should install the forge server jar to `/opt/mscs/server/forge-1.16.4-35.1.7/forge-1.16.4-35.1.7.jar`
+and a bunch of library files in `/opt/mscs/server/forge-1.16.4-35.1.7/libraries/`.
 
 Create a new server (if necessary):
 
@@ -40,17 +41,27 @@ cd /opt/mscs/worlds/forge
 
 Modify the `mscs.properties` file and add/alter these lines, replacing versions and file paths as needed:
 
+```bash
+editor /opt/mscs/worlds/forge/mscs.properties
+```
+
+Add this
+
 ```ini
-mscs-client-version=1.8.4
-mscs-server-version=1.8.4
-mscs-server-jar=forge-1.8.9-11.15.1.1722-universal.jar
+mscs-client-version=1.16.4
+mscs-server-version=1.16.4
+mscs-server-jar=forge-1.16.4-35.1.7/forge-1.16.4-35.1.7.jar
 mscs-server-url=
 ```
 
-Start the server:
+You may also want to increase the initial RAM and possibly even the maximum RAM.
 
-```bash
-mscs start forge
+> Minimum default is 128M  
+> Maximum default is 2048M
+
+```ini
+mscs-initial-memory=1024M
+mscs-maximum-memory=3048M
 ```
 
 If the server fails to start, the `eula.txt` file may need to be edited and accepted:
@@ -59,18 +70,31 @@ If the server fails to start, the `eula.txt` file may need to be edited and acce
 editor /opt/mscs/worlds/forge/eula.txt
 ```
 
+Change `false` to `true`
+
+```ini
+eula=true
+```
+
+Stop then Start the server:
+
+```bash
+mscs stop forge
+mscs start forge
+```
+
 The server should start up and run
 
 The server startup can be monitored by running:
 
 ```bash
-mscs console forge
+mscs watch forge
 ```
 
-Once you are done watching the server boot up, you can press `<Ctrl-D>` to detach.
+Once you are done watching the server boot up, you can press `<Ctrl-C>` to detach.
 
 Simply add mods as you would normally by dragging them into the `/opt/mscs/worlds/forge/mods` folder, assuming `forge`
 is the name of your world.
 
-[forge]: http://www.minecraftforge.net/
-[download]: http://files.minecraftforge.net/
+[forge]: http://www.minecraftforge.net
+[download]: http://files.minecraftforge.net

--- a/docs/mscs/adjusting-world-server-properties/papermc.md
+++ b/docs/mscs/adjusting-world-server-properties/papermc.md
@@ -2,36 +2,36 @@
 layout: default
 title: PaperMC 
 nav_order: 1
-parent: Adjusting world & server properties
+parent: Adjusting World & Server Properties
 permalink: /docs/mscs/adjusting-world-server-properties/papermc
 ---
 
 # PaperMC
 
-Follow the instructions below to set [PaperMC](https://papermc.io/)
-up for a world that already exists (see [getting started](https://minecraftservercontrol.github.io/docs/mscs/getting-started)).
+Follow the instructions below to set [PaperMC][papermc] up for a world that already exists
+(see [getting started](getting-started)).
 
-Make sure the world is not running. 
-Then, set the server download URL in the world's `mscs.properties`:
+Make sure the world is not running. Then, set the server download URL in the world's `mscs.properties`:
 
-```
+```ini
 mscs-server-url=https://papermc.io/ci/job/Paper-$SERVER_VERSION/lastSuccessfulBuild/artifact/paperclip.jar
 ```
 
 Set the JAR to use in the world's `mscs.properties`:
 
-```
+```ini
 mscs-server-jar=paperclip.jar
 ```
 
-Set the server version you want in the world's `mscs.properties`. When you want 
-to update, you can change the version:
+Set the server version you want in the world's `mscs.properties`. When you want  to update, you can change the version:
 
-```
+```ini
 mscs-client-version=1.14
 mscs-server-version=1.14
 ```
 
 That's it! When you start the world, it should now be running PaperMC.
-The PaperMC directories will be created in the world folder. 
 
+The PaperMC directories will be created in the world folder.
+
+[papermc]: https://papermc.io/

--- a/docs/mscs/adjusting-world-server-properties/spigotmc.md
+++ b/docs/mscs/adjusting-world-server-properties/spigotmc.md
@@ -1,54 +1,75 @@
 ---
 layout: default
-title: SpigotMC 
+title: SpigotMC
 nav_order: 2
-parent: Adjusting world & server properties
+parent: Adjusting World & Server Properties
 permalink: /docs/mscs/adjusting-world-server-properties/spigotmc
 ---
 
 # SpigotMC
-Installing [SpigotMC](https://www.spigotmc.org/wiki/spigot/) is very similar to installing Forge. Change to the `/opt/mscs/server/` directory, [download](https://hub.spigotmc.org/jenkins/job/BuildTools/) the SpigotMC installer `BuildTools.jar`, and run the following as the `minecraft` user (`sudo su minecraft`):
 
-    cd /opt/mscs/server
-    wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-    java -jar BuildTools.jar
+Installing [SpigotMC][spigotmc] is very similar to installing Forge.
+Change to the `/opt/mscs/server/` directory, [download][download] the SpigotMC installer `BuildTools.jar`, and run the
+following as the `minecraft` user (`sudo su minecraft`):
+
+```bash
+cd /opt/mscs/server
+wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+java -jar BuildTools.jar
+```
 
 This will build the `spigot-X.X.X.jar` server file.
 
 Create a new server (if necessary):
 
-    mscs create spigot 25565
+```bash
+mscs create spigot 25565
+```
 
 `spigot` can be replaced with any name. Ensure that port `25565` is an unused port, or change it if nessessary.
 
-This will create the directory `spigot` in `/opt/mscs/worlds` as well as the `server.properties` and `mscs.properties` files:
+This will create the directory `spigot` in `/opt/mscs/worlds` as well as the `server.properties` and `mscs.properties`
+files:
 
 Change the directory to the world that was created:
 
-    cd /opt/mscs/worlds/spigot
+```bash
+cd /opt/mscs/worlds/spigot
+```
 
-Modify the `mscs.properties` file and add/alter these lines, replacing versions and file paths as needed. You will
-need to change the `mscs-server-jar` as a bare minimum:
+Modify the `mscs.properties` file and add/alter these lines, replacing versions and file paths as needed. You will need
+to change the `mscs-server-jar` as a bare minimum:
 
-    mscs-client-version=1.8.7
-    mscs-server-version=1.8.7
-    mscs-server-jar=spigot-1.8.7.jar
-    mscs-server-url=
+```ini
+mscs-client-version=1.8.7
+mscs-server-version=1.8.7
+mscs-server-jar=spigot-1.8.7.jar
+mscs-server-url=
+```
 
 Start the server:
 
-    mscs start spigot
+```bash
+mscs start spigot
+```
 
 If the server fails to start, the `eula.txt` file may need to be edited and accepted:
 
-    editor /opt/mscs/worlds/spigot/eula.txt
+```bash
+editor /opt/mscs/worlds/spigot/eula.txt
+```
 
-The server should start up and run  
+The server should start up and run
 The server startup can be monitored by running:
 
-    mscs console spigot
+```bash
+mscs console spigot
+```
 
 Once you are done watching the server boot up, you can press `<Ctrl-D>` to detach.
 
 Simply add plugins as you would normally by dragging them into the `/opt/mscs/worlds/spigot/plugins` folder,
 assuming `spigot` is the name of your world.
+
+[spigotmc]: https://www.spigotmc.org/wiki/spigot/
+[download]: https://hub.spigotmc.org/jenkins/job/BuildTools/

--- a/docs/mscs/adjusting-world-server-properties/technic-tekkit-pack.md
+++ b/docs/mscs/adjusting-world-server-properties/technic-tekkit-pack.md
@@ -2,80 +2,111 @@
 layout: default
 title: Technic/Tekkit Pack
 nav_order: 6
-parent: Adjusting world & server properties
+parent: Adjusting World & Server Properties
 permalink: /docs/mscs/adjusting-world-server-properties/technic-tekkit-pack
 ---
 
 # Technic/Tekkit Pack
-This example was written for [Attack of the B-Team](http://www.technicpack.net/modpack/attack-of-the-bteam.552556) version 1.0.9c
 
-This works for many of the Technic/Tekkit based modpacks, although some settings may need to be adjusted for different modpacks.
+> This example was written for [Attack of the B-Team][attack_bteam] version 1.0.9c
+
+This works for many of the Technic/Tekkit based modpacks, although some settings may need to be adjusted for different
+modpacks.
 
 Create the world:
 
-    mscs create bteam 25565
+```bash
+mscs create bteam 25565
+```
 
 `bteam` can be replaced with any name. Ensure that port `25565` is an unused port, or change it if nessessary.
 
-This will create the directory `bteam` in `/opt/mscs/worlds` as well as the `server.properties` and `mscs.properties` files:
+This will create the directory `bteam` in `/opt/mscs/worlds` as well as the `server.properties` and `mscs.properties`
+files:
 
 Change the directory to the world that was created:
 
-    cd /opt/mscs/worlds/bteam
+```bash
+cd /opt/mscs/worlds/bteam
+```
 
 Rename `server.properties` to `server.properties.bak` so a back up of these settings is available
 
-    mv server.properties server.properties.bak
+```bash
+mv server.properties server.properties.bak
+```
 
 These settings can be used in case `server.properties` is overwritten or deleted
 
-    level-name=bteam
-    server-port=25565
-    server-ip=
-    enable-query=true
-    query.port=25565
+```ini
+level-name=bteam
+server-port=25565
+server-ip=
+enable-query=true
+query.port=25565
+```
 
-[Download](http://www.technicpack.net/modpack/attack-of-the-bteam.552556) the mod pack to the world directory
+[Download][download] the mod pack to the world directory
 
-    wget http://servers.technicpack.net/Technic/servers/bteam/BTeam_Server_v1.0.12c.zip
+```bash
+wget http://servers.technicpack.net/Technic/servers/bteam/BTeam_Server_v1.0.12c.zip
+```
 
 Unzip the mod pack
 
-    unzip <current_version>.zip
+```bash
+unzip <current_version>.zip
+```
 
-While unzipping, it may ask to overwrite `server.properties`  
+While unzipping, it may ask to overwrite `server.properties`
+
 If you first renamed `server.properties` to `server.properties.bak` it should not ask to overwrite
 
 Move or remove the zip
 
-    mv <current_version>.zip /path/to/final/location/
-    rm <current_version>.zip
+```bash
+mv <current_version>.zip /path/to/final/location/
+rm <current_version>.zip
+```
 
-Edit `mscs.properties` and add these settings  
+Edit `mscs.properties` and add these settings
+
 If a setting below already exists in `mscs.properties`, replace it with these
 
-    mscs-client-version=1.6.4
-    mscs-initial-memory=2G
-    mscs-maximum-memory=3G
-    mscs-server-jar=BTeam.jar
-    mscs-server-location=/opt/mscs/worlds/bteam
+```ini
+mscs-client-version=1.6.4
+mscs-initial-memory=2G
+mscs-maximum-memory=3G
+mscs-server-jar=BTeam.jar
+mscs-server-location=/opt/mscs/worlds/bteam
+```
 
-Merge the settings from `server.properties.bak` to the `server.properties` file created by the Technic pack.  
+Merge the settings from `server.properties.bak` to the `server.properties` file created by the Technic pack.
+
 You should replace any setting from Technic's `server.properties` with the setting found in the backup `server.properties.bak`
 
-    level-name=bteam
-    server-port=25565
-    server-ip=
-    enable-query=true
-    query.port=25565
+```ini
+level-name=bteam
+server-port=25565
+server-ip=
+enable-query=true
+query.port=25565
+```
 
 Start the server
 
-    mscs start bteam
+```bash
+mscs start bteam
+```
 
-The server should start up and run  
+The server should start up and run
 The server startup can be monitored by running:
 
-    mscs console bteam
+```bash
+mscs console bteam
+```
 
 Once you are done watching the server boot up, you can press `<Ctrl-D>` to detach.
+
+[attack_bteam]: http://www.technicpack.net/modpack/attack-of-the-bteam.552556
+[download]: http://www.technicpack.net/modpack/attack-of-the-bteam.552556

--- a/docs/mscs/backups.md
+++ b/docs/mscs/backups.md
@@ -8,7 +8,7 @@ permalink: /docs/mscs/backups
 # Backups
 {: .no_toc }
 
-## Table of contents
+## Table of Contents
 {: .no_toc .text-delta }
 
 1. TOC
@@ -16,35 +16,46 @@ permalink: /docs/mscs/backups
 
 ---
 
-## Using backup
+## Using Backup
+
 To backup:
 
-    mscs backup <world>
+```bash
+mscs backup <world>
+```
 
 Where `<world>` is the world to backup. Leaving `<world>` off will back up all worlds.
 
-By default, backups are saved in `/opt/mscs/backups`. The location backups are saved can be configured by changing `mscs-backup-location` in `mscs.defaults` or the world's `mscs.properties` config file (See [adjusting world & server properties](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties)).
+By default, backups are saved in `/opt/mscs/backups`. The location backups are saved can be configured by changing
+`mscs-backup-location` in `mscs.defaults` or the world's `mscs.properties` config file
+(See [Adjusting World & Server Properties](adjusting-world-server-properties)).
 
 ---
 
-## Scheduling backups
-To schedule backups so they run periodically, please see [scheduling tasks](https://minecraftservercontrol.github.io/docs/mscs/scheduling-tasks).
+## Scheduling Backups
+
+To schedule backups so they run periodically, please see [scheduling tasks](scheduling-tasks).
 
 ---
 
-## Viewing & restoring backups
-You can view the backups created by running the `mscs list-backups` command, and restore a backup using the `mscs restore-backup` command. 
+## Viewing & Restoring Backups
 
-You can specify how long to keep backups by changing the
-`mscs-backup-duration` property in `mscs.defaults` or the world's `mscs.properties` config file (see [adjusting world & server properties](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties)).
+You can view the backups created by running the `mscs list-backups` command, and restore a backup using the
+`mscs restore-backup` command.
 
-### Restoring backup example
+You can specify how long to keep backups by changing the `mscs-backup-duration` property in `mscs.defaults` or the
+world's `mscs.properties` config file (see [Adjusting World & Server Properties](adjusting-world-server-properties)).
+
+### Restoring Backup Example
+
 To list the date and time of all available backups for a world named `alpha`:
 
-    mscs list-backups alpha
+```bash
+mscs list-backups alpha
+```
 
 To restore a specific backup for `alpha`:
 
-    mscs restore-backup alpha 2015-03-25T21:15:11-06:00
-
-
+```bash
+mscs restore-backup alpha 2015-03-25T21:15:11-06:00
+```

--- a/docs/mscs/command-reference.md
+++ b/docs/mscs/command-reference.md
@@ -1,27 +1,26 @@
 ---
 layout: default
-title: Command reference
+title: Command Reference
 nav_order: 10
 permalink: /docs/mscs/command-reference
 ---
 
 # Command Reference
-All commands below assume that you are running them as either the `minecraft`
-user or as `root` (through sudo). Please note that if the script is run as the
-`root` user, all important server processes will be started using the `minecraft`
-user instead for security purposes.
+
+All commands below assume that you are running them as either the `minecraft` user or as `root` (through sudo).
+Please note that if the script is run as the `root` user, all important server processes will be started using the
+`minecraft` user instead for security purposes.
 
 __Usage:  `mscs [<options>] <action>`__
 
 {: .fs-1 }
-The `[<options>]` argument is optional and is not typically used. We list options
-at the end of this page.
+The `[<options>]` argument is optional and is not typically used. We list options at the end of this page.
 
 ---
 
-Actions:
+## Actions
 
-```
+```plain
 start <world1> <world2> <...>
   Start the Minecraft world server(s).  Start all world servers by default.
 
@@ -124,8 +123,9 @@ query <world1> <world2> <...>
   query on all world servers by default.
 ```
 
-Options:
-```
+## Options
+
+```plain
 -c <config_file>
   Read configuration from <config_files> instead of default locations.
 

--- a/docs/mscs/getting-started.md
+++ b/docs/mscs/getting-started.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: Getting started
+title: Getting Started
 nav_order: 3
 permalink: /docs/mscs/getting-started
 ---
 
-# Getting started
+# Getting Started
 {: .no_toc }
 
-## Table of contents
+## Table of Contents
 {: .no_toc .text-delta }
 
 1. TOC
@@ -16,36 +16,41 @@ permalink: /docs/mscs/getting-started
 
 ---
 
-## Creating a new world
+## Creating a New World
+
 The command to create a new world is:
 
-    mscs create [world] [port] <ip>
+```bash
+mscs create [world] [port] <ip>
+```
 
-Where `world` is the name of the world you specify,
-and `port` is the server port (by default, use `25565`).
-`ip` is optional and will be used if you wish to bind a world server to a
-specific network interface (e.g. `127.0.0.1` to enforce local access only).
+Where `world` is the name of the world you specify, and `port` is the server port (by default, use `25565`). `ip` is
+optional and will be used if you wish to bind a world server to a specific network interface (e.g. `127.0.0.1` to
+enforce local access only).
 
-Afterwards, start the server via `mscs start [world]` where `world` is the
-name of the world. The world will then shut down because you have to accept
-the EULA. The EULA can be found in `/opt/mscs/worlds/myWorld` where `myWorld`
-is the name given to the world you created. Once this is accepted,
-you can start the world and it will successfully load up.
+Afterwards, start the server via `mscs start [world]` where `world` is the name of the world. The world will then shut
+down because you have to accept the EULA. The EULA can be found in `/opt/mscs/worlds/myWorld` where `myWorld` is the
+name given to the world you created. Once this is accepted, you can start the world and it will successfully load up.
 
-Please note that, by default, the world created will be 
-running the latest server version. See [adjusting world & server properties](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties)
-for instructions on how to change this.
+Please note that, by default, the world created will be running the latest server version.
+See [Adjusting World & Server Properties](adjusting-world-server-properties) for instructions on how to change this.
 
 ---
 
-## Importing an existing world
-If you wish to import or make a copy of an existing world (perhaps one that
-you have not been using with mscs), simply do the following:
+## Importing an Existing World
 
-For this example, I change to a directory containing a world that I have
-running named `alpha`, and get a directory listing:
+If you wish to import or make a copy of an existing world (perhaps one that you have not been using with mscs), simply
+do the following:
+
+For this example, change to a directory containing a world that is running named `alpha`, and get a directory listing:
+
 ```bash
-$ ls
+ls
+```
+
+Result:
+
+```plain
 alpha
 banned-ips.txt
 banned-players.txt
@@ -55,81 +60,100 @@ ops.txt
 server.properties
 white-list.txt
 ```
+
 Now I simply tell mscs to create a new world from the current directory:
 
 ```bash
 mscs import . alpha 25565
 ```
 
-Alternatively, I could have provided the directory the `alpha` world resides in (named `minecraft_world`
-and located in my Documents folder in the example below) instead of changing directories:
+Alternatively, I could have provided the directory the `alpha` world resides in (named `minecraft_world` and located in
+my Documents folder in the example below) instead of changing directories:
 
 ```bash
 mscs import Documents/minecraft_world alpha 25565
 ```
 
-Please note that, by default, the world created will be 
-running the latest server version. See [adjusting world & server properties](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties)
-for instructions on how to change this.
+Please note that, by default, the world created will be running the latest server version.
+See [Adjusting World & Server Properties](adjusting-world-server-properties) for instructions on how to change this.
 
 ---
 
-## Enabling/disabling worlds
-"Enabled" worlds in MSCS are made available to MSCS commands, 
-whereas "disabled" worlds in MSCS are not. 
+## Enabling/Disabling Worlds
+
+"Enabled" worlds in MSCS are made available to MSCS commands, whereas "disabled" worlds in MSCS are not.
 For instance, commands such as `mscs start` and `mscs backup` can only operate on enabled worlds.
-By default, all worlds are enabled. You may wish to disable a world if you don't use it anymore
-and as such don't want it included when running MSCS commands.
+By default, all worlds are enabled. You may wish to disable a world if you don't use it anymore and as such don't want
+it included when running MSCS commands.
 
-You can enable and disable worlds using the `mscs enable <world1> <world2> <...>` and 
-`mscs disable <world1> <world2> <...>` commands, respectively.
+You can enable and disable worlds using the `mscs enable <world1> <world2> <...>`
+and `mscs disable <world1> <world2> <...>` commands, respectively.
 
 ---
 
-## Listing worlds
-MSCS has three commands to list worlds: `mscs ls`, `mscs list`, and `mscs status`. 
+## Listing Worlds
+
+MSCS has three commands to list worlds: `mscs ls`, `mscs list`, and `mscs status`.
 
 `mscs ls` will tell you what worlds are enabled and disabled, and the ports they are running on:
 
 ```bash
-$ mscs ls
-alex: 25567
-test: 25565
-creative: 25562 (disabled)
-forge: 25563 (disabled)
+mscs ls
+```
+
+Result:
+
+```plain
+  alex: 25567
+  test: 25565
+  creative: 25562 (disabled)
+  forge: 25563 (disabled)
 ```
 
 `mscs list` is similar to `mscs ls`, but provides more detailed info from each world's `server.properties` file:
 
 ```bash
-$ mscs list
-alex:
-  motd=A Minecraft Server    server-ip=    server-port=25567    max-players=20    level-type=default    online-mode=true
-  
-test
-    motd=A Minecraft Server    server-ip=    server-port=25569    max-players=20    level-type=default    online-mode=true
-
+mscs list
 ```
 
-`mscs status`, in contrast to the above commands, runs a [query](https://wiki.vg/Query) of the world(s) to get information such as the player count and memory usage:
+Result:
+
+```plain
+  alex:
+    motd=A Minecraft Server    server-ip=    server-port=25567    max-players=20    level-type=default    online-mode=true
+
+  test
+    motd=A Minecraft Server    server-ip=    server-port=25569    max-players=20    level-type=default    online-mode=true
+```
+
+`mscs status`, in contrast to the above commands, runs a [query](https://wiki.vg/Query) for each world to get
+information such as the player count and memory usage:
 
 ```bash
-$ mscs status
-Minecraft Server Status:
-  alex: not running.
-  test: running version 1.15.2 (1 of 20 users online).
-    Players: Tester123.
-    Process ID: 13548.
-    Memory used: 2522052 kB.
-
+mscs status
 ```
 
- `mscs status` may take a few seconds to return results because it runs a query. Additionally, during the world's first 20-60 seconds after startup, the status will return a `world starting up` message as it waits for the world to fully finish starting up. Please try running the status command again after a short wait if you receive this message.
- 
+Result:
+
+```plain
+Minecraft Server Status:
+  alex: not running.
+  test: running version 1.16.4 (1 of 20 users online).
+    Port: 65565
+    Players: Tester123.
+    Memory used: 1.36GB (2GB allocated)
+    Process ID: 13548.
+```
+
+`mscs status` may take a few seconds to return results because it runs a query.
+Additionally, during the world's first 20-60 seconds after startup, the status will return a `world starting up` message
+as it waits for the world to fully finish starting up. Please try running the status command again after a short wait if
+you receive this message.
 
 ---
 
-## Renaming a world
+## Renaming a World
+
 In this example we want to rename a world named `alpha` to `vanillaMC`:
 
 ```bash

--- a/docs/mscs/installation.md
+++ b/docs/mscs/installation.md
@@ -8,7 +8,7 @@ permalink: /docs/mscs/installation
 # Installation
 {: .no_toc }
 
-## Table of contents
+## Table of Contents
 {: .no_toc .text-delta }
 
 1. TOC
@@ -17,138 +17,164 @@ permalink: /docs/mscs/installation
 ---
 
 ## Dependencies
+
 We've made an attempt to utilize only features that are normally installed in
 most Linux and UNIX environments in this script. However, there may be a few
 requirements that this script has that may not already be in place:
 
-
-* Java JRE                   - The Minecraft server software requires this.
-                               **As of Minecraft 1.12, Java 8 is required.**
-* Perl                       - Most, if not all, Unix and Linux like systems
-                               have this preinstalled.
-* libjson-perl               - Allows the script to read JSON formatted data.
-* libwww-perl                - Allows the script to download data to verify
-                               downloads.
-* liblwp-protocol-https-perl - Allows the script to download data over HTTPS.
-* Python                     - Required by the Minecraft Overviewer mapping
-                               software.
-* GNU Make                   - Allows you to use the Makefile to simplify
-                               installation.
-* GNU Wget                   - Allows the script to download software updates
-                               via the internet.
-* rdiff-backup               - Allows the script to efficiently run backups.
-* rsync                      - Allows the script to efficiently make copies of
-                               files.
-* Socat                      - Allows the script to communicate with the
-                               Minecraft server.
-* Iptables                   - Although not explicitly required, a good
-                               firewall should be installed.
-* Sudo                       - Run processes under other user and groups
-
+- Java JRE - The Minecraft server software requires this. **As of Minecraft 1.12, Java 8 is required.**
+- Perl - Most, if not all, Unix and Linux like systems have this preinstalled.
+- libjson-perl - Allows the script to read JSON formatted data.
+- libwww-perl - Allows the script to download data to verify downloads.
+- liblwp-protocol-https-perl - Allows the script to download data over HTTPS.
+- Python - Required by the Minecraft Overviewer mapping software.
+- GNU Make - Allows you to use the Makefile to simplify installation.
+- GNU Wget - Allows the script to download software updates via the internet.
+- rdiff-backup - Allows the script to efficiently run backups.
+- rsync - Allows the script to efficiently make copies of files.
+- Socat - Allows the script to communicate with the Minecraft server.
+- Iptables - Although not explicitly required, a good firewall should be installed.
+- Sudo - Run processes under other user and groups
 
 If you are running Debian, you can make sure that these are
 installed by running:
+
 ```bash
 apt install sudo default-jre perl libjson-perl libwww-perl liblwp-protocol-https-perl python make wget git rdiff-backup rsync socat iptables
 ```
+
 If you are running Ubuntu, you can make sure that these are
 installed by running:
+
 ```bash
 sudo apt-get install default-jre perl libjson-perl libwww-perl liblwp-protocol-https-perl python make wget git rdiff-backup rsync socat iptables
 ```
-If you are running Fedora, you can make sure that these are
-installed by running:
+
+If you are running Fedora, you can make sure that these are installed by running:
+
 ```bash
 yum install java-1.8.0-openjdk perl perl-JSON perl-libwww-perl perl-LWP-Protocol-https python make wget git rdiff-backup rsync socat iptables sudo procps which
 ```
 
-### Configuring the firewall / NAT
-If you are going to run the Minecraft server on your computer, you may need to route some ports to the server (if you are running the Minecraft server with a hosting company, they most likely already have the ports open). Instructions on how to accomplish this are beyond the scope of this document, but here are some things you will need to know:
+### Configuring the Firewall / NAT
 
-* The default port for the Minecraft server is: 25565.
-* If you wish to run multiple world servers using this script, you may want to open a range of ports (for example 25565 - 25575).
-* If you are using BungeeCord, you will most likely need to only open the default port: 25565.
+If you are going to run the Minecraft server on your computer, you may need to route some ports to the server (if you
+are running the Minecraft server with a hosting company, they most likely already have the ports open). Instructions on
+how to accomplish this are beyond the scope of this document, but here are some things you will need to know:
 
-See the [iptables.rules](https://github.com/MinecraftServerControl/mscs/blob/master/iptables.rules) file for a very basic set of rules that you can use with the Iptables firewall.
+- The default port for the Minecraft server is: 25565.
+- If you wish to run multiple world servers using this script, you may want to open a range of ports
+  (for example 25565 - 25575).
+- If you are using BungeeCord, you will most likely need to only open the default port: 25565.
+
+See the [iptables.rules][iptables_rules] file for a very basic set of rules that you can use with the Iptables firewall.
 
 ---
 
-## Quick start
+## Quick Start
+
 The fastest way to install the script is to clone the git repository and run the included Makefile:
+
 ```bash
 git clone https://github.com/MinecraftServerControl/mscs.git && cd mscs
 sudo make install
 ```
-This will, by default, create a user to perform MSCS tasks
-called `minecraft` and give it access to write in the `/opt/mscs` folder.
-If there are no errors, then you can proceed to use the script.
 
-[Getting started](https://minecraftservercontrol.github.io/docs/mscs/getting-started){: .btn .btn-purple }
+This will, by default, create a user to perform MSCS tasks called `minecraft` and give it access to write in the
+`/opt/mscs` folder. If there are no errors, then you can proceed to use the script.
 
-If you get a `permission denied` error, please see the [troubleshooting](https://minecraftservercontrol.github.io/docs/mscs/troubleshooting-issues) page.
+[Getting started](getting-started){: .btn .btn-purple }
+
+If you get a `permission denied` error, please see the [troubleshooting](troubleshooting-issues) page.
 
 ---
 
-## Manual installation
-If the instructions above do not work (i.e. fails on `sudo make install`) or if the installation requires custom locations, user accounts, or settings, then follow the instructions below.
+## Manual Installation
 
-To get a server to run the MSCS script on startup, and cleanly stop the server on shutdown, the [MSCS](https://github.com/MinecraftServerControl/mscs/blob/master/mscs) script must be copied to `/usr/local/bin/`, have execute permissions set, and the system must run the script on startup and shutdown. For Bash completion support, the `mscs.completion` script must be copied to `/etc/bash_completion.d/`. For security reasons, the script runs with an account named `minecraft` rather than `root`. The `minecraft` account must be created before the script is used.
+If the instructions above do not work (i.e. fails on `sudo make install`) or if the installation requires custom
+locations, user accounts, or settings, then follow the instructions below.
+
+To get a server to run the MSCS script on startup, and cleanly stop the server on shutdown,
+the [MSCS][mscs] script must be copied to `/usr/local/bin/`, have execute permissions set, and the system must run the
+script on startup and shutdown. For Bash completion support, the `mscs.completion` script must be copied to
+`/etc/bash_completion.d/`. For security reasons, the script runs with an account named `minecraft` rather than `root`.
+The `minecraft` account must be created before the script is used.
 
 1. Create the `minecraft` user:
+
 ```bash
 useradd --system --user-group --create-home -K UMASK=0022 --home /opt/mscs minecraft
 ```
 
 2. Install the script:
+
 ```bash
 sudo install -m 0755 msctl /usr/local/bin/msctl
 sudo install -m 0755 mscs /usr/local/bin/mscs
 ```
 
 3. If using systemd (ie. Ubuntu 15.04+), link the script to the server's startup and shutdown sequences:
+
 ```bash
 sudo install -m 0644 mscs.service /etc/systemd/system/mscs.service
 sudo systemctl -f enable mscs.service
 ```
 
-4. If using SysV-style, upstart, or similar (ie. Ubuntu 14.10 and lower) link the script to your server's startup and shutdown   sequences:
+4. If using SysV-style, upstart, or similar (ie. Ubuntu 14.10 and lower) link the script to your server's startup and
+shutdown sequences:
+
 ```bash
 sudo ln -s /usr/local/bin/mscs /etc/init.d/mscs
 sudo update-rc.d mscs defaults
 ```
 
 5. Add Bash Completion support:
+
 ```bash
 sudo install -m 0644 mscs.completion /etc/bash_completion.d/mscs
 ```
 
 The Minecraft server software will be automatically downloaded to the following location on the first run:
+
 ```bash
 /opt/mscs/server/
 ```
 
 ---
 
-## Multi-user setup
-MSCS has the ability to store server and world data on a user-by-user basis, allowing multiple users to run their respective worlds while preserving the data of other user worlds.
+## Multi-user Setup
+
+MSCS has the ability to store server and world data on a user-by-user basis, allowing multiple users to run their
+respective worlds while preserving the data of other user worlds.
 
 > Example: Two user accounts are available on a server: `bob` and `jason`.  
-  `bob` should only be able to run and modify Bob's worlds.  
-  `jason` should only be able to run and modify Jason's worlds.  
-  Each user can have their own properties and world locations
+> `bob` should only be able to run and modify Bob's worlds.  
+> `jason` should only be able to run and modify Jason's worlds.  
+> Each user can have their own properties and world locations
 
-To accomplish this, direct users to use `msctl` in place of `mscs` when running commands (see [command reference](https://minecraftservercontrol.github.io/docs/mscs/command-reference)). That's it!
+To accomplish this, direct users to use `msctl` in place of `mscs` when running commands
+(see [command reference](command-reference)). That's it!
 
 For instance, to create a world named `world`:
 
-    msctl create world 25565
+```bash
+msctl create world 25565
+```
 
 To start `world`:
 
-    msctl start world
+```bash
+msctl start world
+```
 
 For all commands, replace the `mscs` prefix with `msctl`.
 
-By default, the location of each users' worlds will be saved to `$HOME/mscs/worlds`, where `$HOME` is the home directory of the user. So if `bob` is logged in, and Bob's home directory is `/home/bob`, Bob's worlds will be saved to `/home/bob/mscs/worlds`.
+By default, the location of each users' worlds will be saved to `$HOME/mscs/worlds`, where `$HOME` is the home directory
+of the user. So if `bob` is logged in, and Bob's home directory is `/home/bob`, Bob's worlds will be saved to
+`/home/bob/mscs/worlds`.
 
-**Please note: MSCS currently does not check if a server port is free for use when creating or running worlds. All users will need to coordinate which ports are being used so no conflicts occur.**
+**Please note: MSCS currently does not check if a server port is free for use when creating or running worlds. All users
+will need to coordinate which ports are being used so no conflicts occur.**
+
+[iptables_rules]: https://github.com/MinecraftServerControl/mscs/blob/master/iptables.rules
+[mscs]: https://github.com/MinecraftServerControl/mscs/blob/master/mscs

--- a/docs/mscs/mapping.md
+++ b/docs/mscs/mapping.md
@@ -6,9 +6,11 @@ permalink: /docs/mscs/mapping
 ---
 
 # Mapping
+
 {: .no_toc }
 
-## Table of contents
+## Table of Contents
+
 {: .no_toc .text-delta }
 
 1. TOC
@@ -17,54 +19,70 @@ permalink: /docs/mscs/mapping
 ---
 
 ## Setting up mapping
-Overviewer is the mapping software that MSCS uses. 
-It has pretty straightforward documentation to download and install the software:
 
-* [Debian/Ubuntu](http://overviewer.org/debian/info)
-* [RHEL/CentOS/Fedora](http://overviewer.org/rpms/info)
+Overviewer is the mapping software that MSCS uses. It has pretty straightforward documentation for installation:
 
-You can also [download](http://overviewer.org/downloads) premade binaries for
-supported systems, or build your own binary from source if needed.
+- [Debian / Ubuntu][install_debian]
+- [CentOS / RHEL / Fedora][install_rhel]
 
-__Once you follow the install page, come back here for further instructions.
-Don't read the "Running the Overviewer" section, as it will differ in MSCS.__
+For Debian / Ubuntu, we suggest either [downloading the premade binaries][download] or
+[building Overviewer from source][building] instead using their apt repository as it is broken on the newer versions of
+Debian / Ubuntu.
+
+__Once you follow the install page, come back here for further instructions. Don't read the "Running the Overviewer"
+section, as it will differ in MSCS.__
 
 ### Configuring Overviewer
-In the `mscs.defaults` file 
-(see [adjusting world & server properties](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties)), 
-you'll find various Overviewer mapping settings which you change to your liking.
+
+In the `mscs.defaults` file (see [Adjusting World & Server Properties](adjusting-world-server-properties)), you'll find
+various Overviewer mapping settings which you change to your liking.
+
 We've listed the map-related settings below:
-    
-* `mscs-overviewer-bin`: This is the location for the Overviewer binary.                                                               If you manually installed Overviewer to another location, you can enter the location here.
-* `mscs-overviewer-url`: A clickable link for users in chat to view the overviewer website.
-* `mscs-maps-location`: The location to store the generated maps. Change this value
+
+- `mscs-overviewer-bin`: This is the location for the Overviewer binary.
+  If you manually installed Overviewer to another location, you can enter the location here.
+- `mscs-overviewer-url`: A clickable link for users in chat to view the overviewer website.
+- `mscs-maps-location`: The location to store the generated maps. Change this value
    to your web-server folder, e.g. `var/www/` (or symlink your web-server folder to this value).
-* `mscs-maps-url`: The link to be displayed in chat to view the maps when mapping is complete. 
+- `mscs-maps-url`: The link to be displayed in chat to view the maps when mapping is complete.
 
+### Changing the Default Rendering Settings
 
-### Changing the default rendering settings
-By default, we've set up MSCS to render the overworld, the nether, the end, and cave systems 
-with Overviewer's "normal" render settings. However, Overviewer has many different render 
-modes which you can apply to as many or as few dimensions of your world(s) as you like.
+By default, we've set up MSCS to render the overworld, the Nether, the End, and cave systems with Overviewer's "normal"
+render settings. However, Overviewer has many different render modes which you can apply to as many or as few dimensions
+of your world(s) as you like.
 
-All you have to do is change the config file, which is located at 
-`/opt/mscs/worlds/myWorld/overviewer_settings.py`, where `myWorld` is the name of your world.
+All you have to do is change the config file, which is located at `/opt/mscs/worlds/myWorld/overviewer_settings.py`,
+where `myWorld` is the name of your world.
 
-To view more information on render modes and how to customize the config file, 
-[click here](http://docs.overviewer.org/en/latest/config/#examples).
+To view more information on render modes and how to customize the config file, [click here][config].
 
 ---
 
-## Mapping world(s)
+## Mapping World(s)
+
 After you've changed the settings, run:
 
-    mscs map <world>
+```bash
+mscs map <world>
+```
 
-Where `<world>` is the name of the world you would like to get mapped.
-Omit the world name to map all worlds.
+Where `<world>` is the name of the world you would like to get mapped. Omit the world name to map all worlds.
 
-Please note that in order for the map to update new changes in the world,
-you need to run Overviewer periodically.
-Please see [scheduling tasks](https://minecraftservercontrol.github.io/docs/mscs/scheduling-tasks) for more information
+Please note that in order for the map to update new changes in the world, you need to run Overviewer periodically.
+Please see [scheduling tasks](scheduling-tasks) for more information
 
-**Bug Note**: as of May 2020, there is a bug in Overviewer that occurs in certain system installations that have multiple Minecraft versions located in the `/opt/mscs/.minecraft/versions` folder. In systems with this bug, the `mscs map` command will hang and mapping will never complete ([see Issue #238](https://github.com/MinecraftServerControl/mscs/issues/238)). If running the `mscs map` command hangs and never completes, and you have multiple versions of minecraft located in the `/opt/mscs/.minecraft/versions` folder, please try deleting all versions except the version that you need for your world and attempt mapping again. If you're still having issues, [please submit an issue on Github](https://github.com/MinecraftServerControl/mscs/issues/).
+**Bug Note**: as of May 2020, there is a bug in Overviewer that occurs in certain system installations that have
+multiple Minecraft versions located in the `/opt/mscs/.minecraft/versions` folder. In systems with this bug, the
+`mscs map` command will hang and mapping will never complete (see [Issue #238][map_issue]).
+If running the `mscs map` command hangs and never completes, and you have multiple versions of minecraft located in the
+`/opt/mscs/.minecraft/versions` folder, please try deleting all versions except the version that you need for your world
+and attempt mapping again. If you're still having issues, [please submit an issue on Github][mscs_issues].
+
+[install_debian]: http://docs.overviewer.org/en/latest/installing/#debian-ubuntu
+[install_rhel]: http://docs.overviewer.org/en/latest/installing/#centos-rhel-fedora
+[download]: http://overviewer.org/downloads
+[building]: http://docs.overviewer.org/en/latest/building/
+[config]: http://docs.overviewer.org/en/latest/config/
+[map_issue]: https://github.com/MinecraftServerControl/mscs/issues/238
+[mscs_issues]: https://github.com/MinecraftServerControl/mscs/issues/

--- a/docs/mscs/scheduling-tasks.md
+++ b/docs/mscs/scheduling-tasks.md
@@ -1,24 +1,22 @@
 ---
 layout: default
-title: Scheduling tasks
+title: Scheduling Tasks
 nav_order: 7
 permalink: /docs/mscs/scheduling-tasks
 ---
 
-# Scheduling tasks
+# Scheduling Tasks
 {: .no_toc }
 
-Schedule automatic backups, restarts, mapping and more 
-using MSCS and cron, a scheduler software built into UNIX
-that can run programs on a set interval of time. 
+Schedule automatic backups, restarts, mapping and more using MSCS and cron, a scheduler software built into UNIX that
+can run programs on a set interval of time.
 {: .fs-6 .fw-300 }
 
 ---
 
-Any MSCS command can be scheduled using cron. Commands
-that may be of interest include:
+Any MSCS command can be scheduled using cron. Commands that may be of interest include:
 
-```
+```bash
 mscs map
 mscs backup
 mscs log-rotate
@@ -28,8 +26,7 @@ mscs broadcast
 
 ---
 
-Below is an example of one way you could setup to backup a
-world every 2 hours:
+Below is an example of one way you could setup to backup a world every 2 hours:
 
 Edit the crontab file for the `minecraft` user using `sudo`:
 
@@ -48,20 +45,16 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 0 */2 * * *  mscs backup myWorld
 ```
 
-* We define HOME and PATH because `cron` may not do it for us. The HOME and PATH we've
-  defined above are the default values set with the default installation.
-  If you did  not follow the default installation, *Make sure that
-  PATH and HOME match the environment on your system.* 
+- We define `HOME` and `PATH` because `cron` may not do it for us. The `HOME` and `PATH` we've defined above are the
+  default values set with the default installation. If you did not follow the default installation, *Make sure that
+  `PATH` and `HOME` match the environment on your system.*
+- `0 */2 * * *` is the time interval to backup. This particular expression means backup every 2 hours.
+  We list some more common examples below.
+- `myWorld` is the name of the world you wish to backup. Omitting this will backup all worlds.
 
-* `0 */2 * * *` is the time interval to backup. This particular expression
-  means backup every 2 hours. We list some more common examples below.
+---
 
-* `myWorld` is the name of the world you wish to backup. Omitting this will
-  backup all worlds.
- 
- ---
- 
-## Scheduling examples
+## Scheduling Examples
 
 Run the backup hourly.
 

--- a/docs/mscs/troubleshooting-issues.md
+++ b/docs/mscs/troubleshooting-issues.md
@@ -1,15 +1,14 @@
 ---
 layout: default
-title: Troubleshooting/issues
+title: Troubleshooting/Issues
 nav_order: 9
 permalink: /docs/mscs/troubleshooting-issues
 ---
 
 # Troubleshooting
 
-If you get a `permission denied` error when attempting to
-run a `mscs` command, please ensure that the `minecraft`
-user has the correct permissions set:
+If you get a `permission denied` error when attempting to run a `mscs` command, please ensure that the `minecraft` user
+has the correct permissions set:
 
 ```bash
 chmod -R u+w /opt/mscs
@@ -20,12 +19,23 @@ chown -R minecraft:minecraft /opt/mscs
 
 # Issues
 
-We have only tested this code in a Debian/Ubuntu environment, but there is no reason that it shouldn't work in any appropriately configured UNIX-like environment, including Apple Mac OSX and the other BSD variants, with only minor modifications. If you experience errors running this script, please post a copy of the error message and a note detailing the operating environment where the error occurs to the support thread, and we will try to work out a solution with you
+We have only tested this code in a Debian/Ubuntu environment, but there is no reason that it shouldn't work in any
+appropriately configured UNIX-like environment, including Apple Mac OSX and the other BSD variants, with only minor
+modifications. If you experience errors running this script, please post a copy of the error message and a note
+detailing the operating environment where the error occurs to the support thread, and we will try to work out a
+solution with you
 
-For a list of current and past issues, or to submit an issue or question you have,
-please visit the [Github issues page](https://github.com/MinecraftServerControl/mscs/issues).
+For a list of current and past issues, or to submit an issue or question you have, please visit the
+[Github issues page][mscs_issues].
 
 ## Overviewer Bug Note
 
-As of May 2020, there is a bug in Overviewer that occurs in certain system installations that have multiple Minecraft versions located in the `/opt/mscs/.minecraft/versions` folder. In systems with this bug, the `mscs map` command will hang and mapping will never complete ([see Issue #238](https://github.com/MinecraftServerControl/mscs/issues/238)). If running the `mscs map` command hangs and never completes, and you have multiple versions of minecraft located in the `/opt/mscs/.minecraft/versions` folder, please try deleting all versions except the version that you need for your world and attempt mapping again. If you're still having issues, [please submit an issue on Github](https://github.com/MinecraftServerControl/mscs/issues/).
+Aas of May 2020, there is a bug in Overviewer that occurs in certain system installations that have
+multiple Minecraft versions located in the `/opt/mscs/.minecraft/versions` folder. In systems with this bug, the
+`mscs map` command will hang and mapping will never complete (see [Issue #238][map_issue]).
+If running the `mscs map` command hangs and never completes, and you have multiple versions of minecraft located in the
+`/opt/mscs/.minecraft/versions` folder, please try deleting all versions except the version that you need for your world
+and attempt mapping again. If you're still having issues, [please submit an issue on Github][mscs_issues].
 
+[map_issue]: https://github.com/MinecraftServerControl/mscs/issues/238
+[mscs_issues]: https://github.com/MinecraftServerControl/mscs/issues/

--- a/docs/mscs/updating.md
+++ b/docs/mscs/updating.md
@@ -8,7 +8,7 @@ permalink: /docs/mscs/updating
 # Updating
 {: .no_toc }
 
-## Table of contents
+## Table of Contents
 {: .no_toc .text-delta }
 
 1. TOC
@@ -17,29 +17,41 @@ permalink: /docs/mscs/updating
 ---
 
 ## Updating MSCS
+
 Periodically Minecraft Server Control Script is updated to address bug fixes and add new features.
 
-### Quick-start installation
-If you followed the [quick start installation](https://minecraftservercontrol.github.io/docs/mscs/installation#quick-start), you can update MSCS by `cd`'ing into the folder where you downloaded MSCS. Then, type:
+### Quick-start Installation
+
+If you followed the [quick start installation](installation#quick-start), you can update MSCS by running the following
+in the folder where you downloaded MSCS:
 
 ```bash
 git pull
 sudo make update
 ```
 
-### Manual installation
-If you followed the [manual installation](https://minecraftservercontrol.github.io/docs/mscs/installation#manual-installation), you will need to repeat the installation process again to update the script.
+### Manual Installation
+
+If you followed the [manual installation](installation#manual-installation), you will need to repeat the installation
+process again to update the script.
 
 ---
 
-## Updating Minecraft server version
+## Updating Minecraft Server Version
 
 ### Vanilla server
-If you are running a regular, unmodded Minecraft server (i.e. one where you didn't specify `mscs-server-jar` such a SpigotMC or Forge), you can simply type `mscs update <world1> <world2> <...>` to update the specific world(s) to the latest Minecraft version. Note that you can specify if you want to update to the latest Minecraft release or to the latest Minecraft snapshot by specifying `mscs-version-type` as `release` (default) or `snapshot` in the world's `mscs.properties`.
 
-### Modded server
-If you are running a modded Minecraft server (i.e. one where you specified `mscs-server-jar` to something like SpigotMC or Forge), the `mscs update` command will not work. This is because the `mscs update` command functions by looking at the `version_manifest.json` file located in `/opt/mscs/version_manifest.json` that is downloaded from Mojang. 
+If you are running a regular, unmodded Minecraft server (i.e. one where you didn't specify `mscs-server-jar` such a
+SpigotMC or Forge), you can simply type `mscs update <world1> <world2> <...>` to update the specific world(s) to the
+latest Minecraft version. Note that you can specify if you want to update to the latest Minecraft release or to the
+latest Minecraft snapshot by specifying `mscs-version-type` as `release` (default) or `snapshot` in the world's
+`mscs.properties`.
 
-We recommend you follow the instructions listed for [PaperMC](https://minecraftservercontrol.github.io/docs/mscs/adjusting-world-server-properties/papermc) to update modded servers, or re-download the mod to the latest version if all else fails.
- 
- 
+### Modded Server
+
+If you are running a modded Minecraft server (i.e. one where you specified `mscs-server-jar` to something like SpigotMC
+or Forge), the `mscs update` command will not work. This is because the `mscs update` command functions by looking at
+the `version_manifest.json` file located in `/opt/mscs/version_manifest.json` that is downloaded from Mojang.
+
+We recommend you follow the instructions listed for [PaperMC](adjusting-world-server-properties/papermc) to update
+modded servers, or re-download the mod to the latest version if all else fails.

--- a/index.md
+++ b/index.md
@@ -9,23 +9,26 @@ redirect_from: "/"
 
 # Minecraft Server Control Script Docs
 {: .fs-9 }
+
 Minecraft Server Control Script (MSCS) is a server-management script for UNIX and Linux powered Minecraft servers.
 {: .fs-6 .fw-300 }
 
-[Installation](/docs/mscs/installation){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 } [View it on GitHub](https://github.com/MinecraftServerControl/mscs){: .btn .fs-5 .mb-4 .mb-md-0 }
+[Installation](/docs/mscs/installation){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[View it on GitHub](https://github.com/MinecraftServerControl/mscs){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 ---
 
 Features include:
 
-* Run multiple Minecraft worlds.
-* Start, stop, and restart single or multiple worlds.
-* Create, delete, disable, and enable worlds.
-* Includes support for additional server types: Forge, BungeeCord, SpigotMC, etc.
-* Users automatically notified of important server events.
-* LSB and systemd compatible init script, allows for seamless integration with your server's startup and shutdown sequences.
-* Map worlds using the Minecraft Overviewer mapping software.
-* Automatically backup worlds, remove backups older than X days, and restart worlds.
-* Update the server and client software automatically.
-* Send commands to a world server from the command line.
-* And more!
+- Run multiple Minecraft worlds.
+- Start, stop, and restart single or multiple worlds.
+- Create, delete, disable, and enable worlds.
+- Includes support for additional server types: Forge, BungeeCord, SpigotMC, etc.
+- Users automatically notified of important server events.
+- LSB and systemd compatible init script, allows for seamless integration with your server's startup and shutdown
+  sequences.
+- Map worlds using the Minecraft Overviewer mapping software.
+- Automatically backup worlds, remove backups older than X days, and restart worlds.
+- Update the server and client software automatically.
+- Send commands to a world server from the command line.
+- And more!


### PR DESCRIPTION
- Updated documentation for overviewer recommending the use of binaries or building instead of using apt
- Updated the example output of `mscs status`
- Updated global and per-server properties to match script
  - Add help for properties that set replacement variables
- Capitalize page titles and headers
- Clean up markdown using remark-lint with the the `remark-preset-lint-recommended` ruleset
  - Replace indented code blocks with code fences
  - Wrap lines to 120
  - Replace most links with footer references
  - Add syntax highlighting to code blocks
- Update installing a Forge server documentation