### PR TITLE
Updated Redhat-Based Linux Installation Section

### DIFF
--- a/docs/mscs/installation.md
+++ b/docs/mscs/installation.md
@@ -48,9 +48,14 @@ sudo apt-get install default-jre perl libjson-perl libwww-perl liblwp-protocol-h
 If you are running Fedora, Redhat, or CentOS, you can make sure that the dependencies are installed by running the following command:
 
 ```bash
-sudo yum install java-1.8.0-openjdk perl perl-JSON perl-libwww-perl perl-LWP-Protocol-https util-linux python make wget git rdiff-backup rsync socat iptables sudo procps which
+sudo dnf install java-1.8.0-openjdk perl perl-JSON perl-libwww-perl perl-LWP-Protocol-https util-linux python3 make wget git rdiff-backup rsync socat iptables sudo procps which
 ```
 **Note:** the `java-1.8.0-openjdk` package is the official Fedora / Redhat / Centos package that provides Java 8, which is only supported for Minecraft versions up to Minecraft 1.16. As of July 2021, there is no official Fedora / Redhat / CentOS Java 16 package. Thus, if you want to run Minecraft 1.17+, you will either have to download Java 16 manually or add it from an unofficial, third party package repository.
+**Additional Note:** if you are running Redhat Enterprise Linux, you must install and enable the EPEL repository in order to install some of the required packages. You can do so with the following commands (assuming you are running RHEL 8):
+```bash
+sudo subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms
+sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
 
 ---
 


### PR DESCRIPTION
- changed `yum` to `dnf` as `dnf` has been the preferred package manager for awhile now
- updated package `python` to `python3` as `python3` is what Minecraft Overviewer specifies in its installation guide, and `python` returns an error on RHEL8
- added an additional note about installation on RHEL, as `rdiff-backup` is from the EPEL repo which is not installed by default